### PR TITLE
output ToF as bitmap for LED Matrix

### DIFF
--- a/src/components/Blockly/blocks/sensebox-sensors.js
+++ b/src/components/Blockly/blocks/sensebox-sensors.js
@@ -303,20 +303,16 @@ Blockly.Blocks["sensebox_tof_imager"] = {
   init: function () {
     var dropdownOptions = [
       [Blockly.Msg.sensebox_distanz, "DistanzCM"],
+      [Blockly.Msg.sensebox_distanz_bitmap, "DistanzBM"]
     ];
-    var dropdown = new Blockly.FieldDropdown(dropdownOptions, function (
-      option
-    ) {
-      var input =
-        option === "DistanzCM"
-    });
+    var dropdown = new Blockly.FieldDropdown(dropdownOptions);
     this.setColour(getColour().sensebox);
     this.appendDummyInput()
       .appendField(Blockly.Msg.sensebox_tof_imager)
-      this.appendDummyInput()
+    this.appendDummyInput()
       .setAlign(Blockly.ALIGN_RIGHT)
       .appendField(Blockly.Msg.senseBox_value)
-      .appendField(dropdown, "NAME");
+      .appendField(dropdown, "dropdown");
     this.setOutput(true, Types.NUMBER.typeName);
     this.setTooltip(Blockly.Msg.sensebox_tof_imager_tooltip);
   },

--- a/src/components/Blockly/generator/sensebox-led.js
+++ b/src/components/Blockly/generator/sensebox-led.js
@@ -134,7 +134,7 @@ Blockly.Arduino['sensebox_ws2812_matrix_drawPixel'] = function (block) {
 Blockly.Arduino['sensebox_ws2812_matrix_drawBitmap'] = function (block) {
     var dropdown_pin = this.getFieldValue('Port');
     var value = Blockly.Arduino.valueToCode(this, "input", Blockly.Arduino.ORDER_ATOMIC) || '"Keine Eingabe"';
-    var code = `matrix_${dropdown_pin}.drawRGBBitmap(0,0, bitmap_${value}, WIDTH, HEIGHT);\n`;
+    var code = `matrix_${dropdown_pin}.drawRGBBitmap(0,0, ${value}, WIDTH, HEIGHT);\n`;
     code += `matrix_${dropdown_pin}.show();\n`;
     return code;
 }
@@ -218,7 +218,7 @@ Blockly.Arduino['sensebox_ws2812_matrix_bitmap'] = function (block) {
             break;
     }
     Blockly.Arduino.definitions_[`define_bitmap_${dropdown_bitmap}`] = `const uint16_t bitmap_${dropdown_bitmap}[] = {${bitmap}};`;
-    var code =dropdown_bitmap;
+    var code = "bitmap_" + dropdown_bitmap;
     return [code, Blockly.Arduino.ORDER_ATOMIC];
 }
 

--- a/src/components/Blockly/msg/de/sensebox-sensors.js
+++ b/src/components/Blockly/msg/de/sensebox-sensors.js
@@ -233,6 +233,7 @@ senseBox_esp32_photodiode_tooltip: "Die Photodiode misst Lichtintensität. Der a
 sensebox_tof_imager: "TOF Imager",
 sensebox_tof_imager_tooltip: "Der TOF Imager misst die Distanz mithilfe von Infrarotlicht. Der Messwert wird in cm zurückgegeben.",
 sensebox_distanz: "Distanz in cm",
+sensebox_distanz_bitmap: "Distanz als Bitmap (für LED-Matrix)",
 
     };
 

--- a/src/components/Blockly/msg/en/sensebox-sensors.js
+++ b/src/components/Blockly/msg/en/sensebox-sensors.js
@@ -238,4 +238,5 @@ The measured values for temperature, humidity and air pressure can be used direc
   sensebox_tof_imager_tooltip:
     "The TOF imager measures distance using infrared light. The measurement value is returned in centimeters.",
   sensebox_distanz: "Distance in cm",
+  sensebox_distanz_bitmap: "Distance as bitmap (for LED-Matrix)",
 };


### PR DESCRIPTION
![gorgeous-dolphin](https://github.com/sensebox/React-Ardublockly/assets/48286621/f0f82133-dd08-4dce-8fd9-3dbf609a2d25)

Some thoughts:
- should the `Draw bitmap` block perhaps be constrained to only accept bitmaps?
- maybe `bitmap` should be its own type. People might think that they can use it as text but thats not possible (eg serial.printing the bitmap wont work)