### PR TITLE
add checkbox for drawing pixel immediatly or not

### DIFF
--- a/src/components/Blockly/blocks/sensebox-led.js
+++ b/src/components/Blockly/blocks/sensebox-led.js
@@ -221,7 +221,10 @@ Blockly.Blocks['sensebox_ws2812_matrix_drawPixel'] = {
         this.appendDummyInput()
             .appendField(Blockly.Msg.senseBox_ws2812_rgb_matrix_draw_pixel)
             .appendField("Port:")
-            .appendField(new Blockly.FieldDropdown(selectedBoard().digitalPinsRGBMatrix), "Port")
+            .appendField(new Blockly.FieldDropdown(selectedBoard().digitalPinsRGBMatrix), "Port");
+        this.appendDummyInput("show")
+            .appendField(Blockly.Msg.senseBox_ws2812_rgb_matrix_show)
+            .appendField(new Blockly.FieldCheckbox("TRUE"), "SHOW");
         this.appendValueInput("X", "Number")
             .appendField(Blockly.Msg.senseBox_ws2812_rgb_matrix_x);
         this.appendValueInput("Y", "Number")

--- a/src/components/Blockly/generator/sensebox-led.js
+++ b/src/components/Blockly/generator/sensebox-led.js
@@ -133,8 +133,11 @@ Blockly.Arduino['sensebox_ws2812_matrix_drawPixel'] = function (block) {
     var x = Blockly.Arduino.valueToCode(this, 'X', Blockly.Arduino.ORDER_ATOMIC);
     var y = Blockly.Arduino.valueToCode(this, 'Y', Blockly.Arduino.ORDER_ATOMIC);
     var color = Blockly.Arduino.valueToCode(this, 'COLOR', Blockly.Arduino.ORDER_ATOMIC);
+    var show = this.getFieldValue("SHOW");
     var code = `matrix_${dropdown_pin}.drawPixel(${x},${y},matrix_${dropdown_pin}.Color(${color}));\n`;
-    code += `matrix_${dropdown_pin}.show();\n`;
+    if (show === "TRUE") {
+        code += `matrix_${dropdown_pin}.show();\n`;
+    }
     return code;
 }
 

--- a/src/components/Blockly/msg/de/sensebox-led.js
+++ b/src/components/Blockly/msg/de/sensebox-led.js
@@ -49,13 +49,17 @@ export const LED = {
     senseBox_ws2812_rgb_matrix_init_tooltip: `Schließe die LED-Matrix an einen der **digital/analog Ports** an. Dieser Block muss im Setup() verwendet werden.`,
     senseBox_ws2812_rgb_matrix_brightness: `Helligkeit: `,
     senseBox_ws2812_rgb_matrix_print_tooltip: `Zeigt eine Zahl/Text auf dem Display an. 
-    Wenn ein Häckchen am 'Auto-Scroll' gesetzt  wurde, wandert der anzuzeigende Input von rechts nach links über die Matrix. Dies ist hilfreich um langen Input anzuzeigen. Nachfolgender Code wird erst ausgeführt, wenn der gesamte Input über die Matrix gewandert ist.
+    Wenn ein Häkchen am 'Auto-Scroll' gesetzt  wurde, wandert der anzuzeigende Input von rechts nach links über die Matrix. Dies ist hilfreich um langen Input anzuzeigen. Nachfolgender Code wird erst ausgeführt, wenn der gesamte Input über die Matrix gewandert ist.
     Beim Feld 'Color' kannst du eine Farbe für deinen Input wählen.`,
     senseBox_ws2812_rgb_matrix_autoscroll: `Auto-Scroll`,
     senseBox_ws2812_rgb_matrix_draw_pixel: `Pixel setzen`,
     senseBox_ws2812_rgb_matrix_draw_pixel_tooltip: `Färbe ein Pixel an der Position (X,Y).
     Entlang der X-Achse hat die LED-Matrix 12 Pixel und auf der Y-Achse 8.
-    Ein Block zum auswählen der Farbe befindet sich in der LED Kategorie.`,
+    Ein Block zum auswählen der Farbe befindet sich in der LED Kategorie.
+    Wenn du kein Häkchen an 'Zeige sofort' sofort setzt wird die Färbung des Pixels nur vorgemerkt und noch nicht dargestellt.
+    Dies ist hilfreich wenn du viele Pixel auf einmal färben möchtest, da die LED-Matrix sonst jedesmal flackert wenn du ein Pixel färbst.
+    Falls du also mehrere Pixel färbst, solltest du nur beim letzten Block das Häkchen setzen.`,
+    senseBox_ws2812_rgb_matrix_show: `Zeige sofort`,
     senseBox_ws2812_rgb_matrix_x: `X`,
     senseBox_ws2812_rgb_matrix_y: `Y`,
     senseBox_ws2812_rgb_matrix_color: `Farbe`,

--- a/src/components/Blockly/msg/en/sensebox-led.js
+++ b/src/components/Blockly/msg/en/sensebox-led.js
@@ -59,7 +59,11 @@ export const LED = {
   senseBox_ws2812_rgb_matrix_draw_pixel: `Set pixels`,
   senseBox_ws2812_rgb_matrix_draw_pixel_tooltip: `Color a pixel at the position (X,Y).
   Along the X-axis the LED-Matrix has 12 pixels and on the Y-axis 8.
-  You can find the single color block in the LED category.`,
+  You can find the single color block in the LED category.
+  If you do not check the 'Draw immediately' box, the coloring of the pixel is only noted and not yet displayed.
+  This is helpful if you want to color many pixels at once, as otherwise the LED matrix will flicker every time you color a pixel.
+  So if you are coloring several pixels, you should only check the box for the last block.`,
+  senseBox_ws2812_rgb_matrix_show: `Draw immediatly`,
   senseBox_ws2812_rgb_matrix_x: `X`,
   senseBox_ws2812_rgb_matrix_y: `Y`,
   senseBox_ws2812_rgb_matrix_color: `Color`,


### PR DESCRIPTION
currently we are always redrawing the whole matrix when just one pixel is changed. This results in a flickering display if several pixels are changed in a row. so I added a checkbox to choose when to trigger the redraw.
Let me know if this is a good addition and if the labels and description for it are understandable