### PR TITLE
replace special characters in variable names with underscores

### DIFF
--- a/src/components/Blockly/generator/variables.js
+++ b/src/components/Blockly/generator/variables.js
@@ -26,8 +26,8 @@ const setVariableFunction = function (defaultValue) {
     var code = "";
     if (myVar !== undefined) {
       Blockly.Arduino.variables_[variableName + myVar.type] =
-        myVar.type + " " + myVar.name + ";\n";
-      code = variableName + " = " + (variableValue || defaultValue) + ";\n";
+        myVar.type + " " + myVar.name.replace(/_/g, '__').replace(/[^a-zA-Z0-9_]/g, '_') + ";\n";
+      code = myVar.name.replace(/_/g, '__').replace(/[^a-zA-Z0-9_]/g, '_') + " = " + (variableValue || defaultValue) + ";\n";
     }
     return code;
   };
@@ -47,7 +47,7 @@ const getVariableFunction = function (block) {
   //   block.getFieldValue("VAR"),
   //   Blockly.Variables.NAME_TYPE
   // );
-  var code = myVar.name;
+  var code = myVar.name.replace(/_/g, '__').replace(/[^a-zA-Z0-9_]/g, '_');
   return [code, Blockly["Arduino"].ORDER_ATOMIC];
 };
 

--- a/src/components/Blockly/msg/de/ui.js
+++ b/src/components/Blockly/msg/de/ui.js
@@ -339,6 +339,7 @@ export const UI = {
 
   display_not_declared:
     "Stelle sicher, dasss du das Display im Setup initialisiert hast.",
+  variable_redeclared: "Stelle sicher, dass du keine Sonderzeichen in deinen Variablennamen verwendest. Dazu gehören z.B. Leerzeichen, Sternchen oder Anführungszeichen.",
   /**
    * Code Editor
    *  */

--- a/src/components/Blockly/msg/en/ui.js
+++ b/src/components/Blockly/msg/en/ui.js
@@ -344,6 +344,7 @@ export const UI = {
 
   suggestion_pre_text: "Maybe you should try:",
   display_not_declared: "Initialise the display in the setup() function",
+  variable_redeclared: "Make sure that you do not use any special characters in your variable names. This includes spaces, asterisks or quotation marks.",
   /**
    * Device Selection
    * */

--- a/src/components/CodeEditor/ErrorView.js
+++ b/src/components/CodeEditor/ErrorView.js
@@ -11,6 +11,7 @@ export const ErrorView = ({ error }) => {
     "'display' was not declared in this scope":
       Blockly.Msg.display_not_declared,
       "redefinition of": Blockly.Msg.variable_redeclared,
+      "conflicting declaration": Blockly.Msg.variable_redeclared,
   };
 
   const getSuggestion = (process) => {

--- a/src/components/CodeEditor/ErrorView.js
+++ b/src/components/CodeEditor/ErrorView.js
@@ -10,6 +10,7 @@ export const ErrorView = ({ error }) => {
   const errorSuggestions = {
     "'display' was not declared in this scope":
       Blockly.Msg.display_not_declared,
+      "redefinition of": Blockly.Msg.variable_redeclared,
   };
 
   const getSuggestion = (process) => {


### PR DESCRIPTION
#355
replaces all special characters with underscores and underscores with double underscores.
Slightly problematic, because if the user declares for example a variable `test*test` and another variable `test&test` both of these will be translated to `test_test` in the code, so it will throw a redeclaration error. I added an ErrorSuggestion for that...