### PR TITLE
use compiler url from store

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ A modern, React-based version of the [senseBox](https://sensebox.de) Ardublockly
 3. Install dependencies:
 
    ```bash
-   npm ci   # Recommended for reproducible builds
-   # or
    npm install   # Alternative
    ```
 

--- a/src/components/Blockly/index.js
+++ b/src/components/Blockly/index.js
@@ -22,9 +22,7 @@
  */
 
 import React from "react";
-import BlocklyComponent from "./BlocklyComponent";
 
-export default BlocklyComponent;
 
 const Block = (p) => {
   const { children, ...props } = p;

--- a/src/components/Blockly/msg/de/ui.js
+++ b/src/components/Blockly/msg/de/ui.js
@@ -349,7 +349,7 @@ export const UI = {
    *  */
   codeeditor_libraries_head: "Installierte Arduino Libraries",
   codeeditor_libraries_text:
-    "Für die Dokumentation sehen Sie sich die installierten Bibliotheken und deren Beispiele an",
+    "Unten stehen alle Arduino Libraries, welche auf dem Compiler installiert sind. Klicke auf eine Library um mehr Informationen zu erhalten.",
   codeeditor_save_code: "Code herunterladen",
   codeeditor_open_code: "Code öffnen",
   codeeditor_reset_code: "Code zurücksetzen",

--- a/src/components/Blockly/msg/en/ui.js
+++ b/src/components/Blockly/msg/en/ui.js
@@ -332,7 +332,7 @@ export const UI = {
    * */
   codeeditor_libraries_head: "Installed Arduino Libraries",
   codeeditor_libraries_text:
-    "For documentation, view the installed libraries and their examples",
+    "Below are all arduino libraries which are installed on the compiler. You can use them in your code. For more information click on the library.",
   codeeditor_save_code: "Download code",
   codeeditor_open_code: "Open code",
   codeeditor_reset_code: "Reset code",

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -25,6 +25,7 @@ const CodeEditor = (props) => {
   const [time, setTime] = useState(null);
   const [value, setValue] = useState("");
   const [resetDialog, setResetDialog] = useState(false);
+  const compilerUrl = store.getState().general.compiler;
 
   const compile = () => {
     setProgress(true);
@@ -36,7 +37,7 @@ const CodeEditor = (props) => {
           : "sensebox-esp32s2",
       sketch: editorRef.current.getValue(),
     };
-    fetch(`${this.props.selectedCompiler}/compile`, {
+    fetch(`${compilerUrl}/compile`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
@@ -53,7 +54,7 @@ const CodeEditor = (props) => {
         //setId(result);
         const filename = "sketch";
         window.open(
-          `${this.props.selectedCompiler}/download?id=${result}&board=${
+          `${compilerUrl}/download?id=${result}&board=${
             store.getState().board.board === "mcu"
               ? "sensebox-mcu"
               : "sensebox-esp32s2"

--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -26,8 +26,6 @@ const CodeEditor = () => {
   const [time, setTime] = useState(null);
   const [value, setValue] = useState("");
   const [resetDialog, setResetDialog] = useState(false);
-  const compilerUrl = store.getState().general.compiler;
-
   const compilerUrl = useSelector((state) => state.general.compiler);
 
   const compile = () => {

--- a/src/components/CodeEditor/LibrariesAccordion.js
+++ b/src/components/CodeEditor/LibrariesAccordion.js
@@ -75,7 +75,7 @@ const LibrariesAccordion = ({ libraries }) => {
                           Author: {library.author}
                         </Typography>
                         <Typography variant="body2" color="textSecondary">
-                          Description: {library.sentence}
+                          {Blockly.Msg.sensorinfo_description}: {library.sentence}
                         </Typography>
                       </>
                     }

--- a/src/components/CodeEditor/LibrariesAccordion.js
+++ b/src/components/CodeEditor/LibrariesAccordion.js
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  Link,
+  Paper,
+} from "@mui/material";
+import * as Blockly from "blockly";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronCircleDown, faChevronDown, faExternalLink } from "@fortawesome/free-solid-svg-icons";
+
+const LibrariesAccordion = ({ libraries }) => {
+  return (
+    <Accordion>
+      <AccordionSummary
+        expandIcon={<FontAwesomeIcon icon={faChevronDown} />}
+        aria-controls="libraries-content"
+        id="libraries-header"
+      >
+        <Typography variant="h6">
+          {Blockly.Msg.codeeditor_libraries_head}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Box
+          sx={{
+            width: "100%",
+            maxHeight: "60vh",
+            overflowY: "auto",
+            backgroundColor: "#fff",
+            p: 2,
+          }}
+        >
+          <Typography variant="body1" paragraph>
+            {Blockly.Msg.codeeditor_libraries_text}
+          </Typography>
+          <List>
+            {libraries.map((library, index) => (
+              <ListItem key={`${library.name}-${index}`} disableGutters>
+                <Paper
+                  elevation={2}
+                  sx={{
+                    width: "100%",
+                    p: 1,
+                    transition: "transform 0.3s, box-shadow 0.3s",
+                    "&:hover": {
+                      transform: "scale(1.02)",
+                      boxShadow: 6,
+                    },
+                  }}
+                >
+                  <ListItemText
+                    primary={
+                      <Link
+                        href={library.website}
+                        target="_blank"
+                        rel="noreferrer"
+                        underline="hover"
+                      >
+                        {library.name} <FontAwesomeIcon icon={faExternalLink} />
+                      </Link>
+                    }
+                    secondary={
+                      <>
+                        <Typography variant="body2" color="textSecondary">
+                          Version: {library.version}
+                        </Typography>
+                        <Typography variant="body2" color="textSecondary">
+                          Author: {library.author}
+                        </Typography>
+                        <Typography variant="body2" color="textSecondary">
+                          Description: {library.sentence}
+                        </Typography>
+                      </>
+                    }
+                  />
+                </Paper>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default LibrariesAccordion;

--- a/src/components/CodeEditor/Sidebar.js
+++ b/src/components/CodeEditor/Sidebar.js
@@ -9,7 +9,6 @@ import { useMonaco } from "@monaco-editor/react";
 import { Button } from "@mui/material";
 import SerialMonitor from "./SerialMonitor.js";
 import axios from "axios";
-import store from "../../store.js";
 import LibrariesAccordion from "./LibrariesAccordion.js";
 
 const Sidebar = () => {
@@ -25,7 +24,6 @@ const Sidebar = () => {
   //     });
   // }, []);
   const monaco = useMonaco();
-  const compilerUrl = store.getState().general.compiler;
   const loadCode = (code) => {
     monaco.editor.getModels()[0].setValue(code);
   };

--- a/src/components/CodeEditor/Sidebar.js
+++ b/src/components/CodeEditor/Sidebar.js
@@ -10,6 +10,7 @@ import { Button } from "@mui/material";
 import SerialMonitor from "./SerialMonitor.js";
 import axios from "axios";
 import store from "../../store.js";
+import LibrariesAccordion from "./LibrariesAccordion.js";
 
 const Sidebar = () => {
   //const [examples, setExamples] = React.useState([]);
@@ -131,42 +132,7 @@ const Sidebar = () => {
           </AccordionDetails>
         </Accordion>
       ) : null}
-      <Accordion>
-        <AccordionSummary
-          expandIcon={""}
-          aria-controls="panel2a-content"
-          id="panel2a-header"
-        >
-          <Typography>{Blockly.Msg.codeeditor_libraries_head}</Typography>
-        </AccordionSummary>
-        <AccordionDetails
-          style={{
-            padding: 0,
-            height: "60vH",
-            backgroundColor: "white",
-          }}
-        >
-          <Typography
-            style={{
-              overflow: "auto",
-              width: "100%",
-              height: "100%",
-              padding: "1rem",
-            }}
-          >
-            <p>{Blockly.Msg.codeeditor_libraries_text}</p>
-            {libraries.map((library, i) => {
-              return (
-                <p key={library.name + i}>
-                  <a href={library.website} target="_blank" rel="noreferrer" >
-                    {library.name} {library.version}
-                  </a>
-                </p>
-              );
-            })}
-          </Typography>
-        </AccordionDetails>
-      </Accordion>
+      <LibrariesAccordion libraries={libraries} />
     </div>
   );
 };

--- a/src/components/CodeEditor/Sidebar.js
+++ b/src/components/CodeEditor/Sidebar.js
@@ -9,6 +9,7 @@ import { useMonaco } from "@monaco-editor/react";
 import { Button } from "@mui/material";
 import SerialMonitor from "./SerialMonitor.js";
 import axios from "axios";
+import store from "../../store.js";
 
 const Sidebar = () => {
   //const [examples, setExamples] = React.useState([]);
@@ -21,6 +22,7 @@ const Sidebar = () => {
   //     });
   // }, []);
   const monaco = useMonaco();
+  const compilerUrl = store.getState().general.compiler;
   const loadCode = (code) => {
     monaco.editor.getModels()[0].setValue(code);
   };
@@ -37,7 +39,7 @@ const Sidebar = () => {
   React.useEffect(() => {
     const fetchLibraries = async () => {
       const { data } = await axios.get(
-        `${process.env.REACT_APP_COMPILER_URL}/libraries`,
+        `${compilerUrl}/libraries`,
         {
           params: {
             format: "json",


### PR DESCRIPTION
fixes #403 
closes #402 

fixed a bug where the compiler url used an old reference to the `.env` and reworked the used libraries accordion in the code editor. 

additionally i fixed a legacy bug which prevented `npm install` from working without using `package-lock.json` and `npm ci`

<img width="633" alt="grafik" src="https://github.com/user-attachments/assets/135e95a5-8c8c-4ea7-a0cc-b36a22f31ffb" />
