### PR TITLE
Fix/mathblock

### DIFF
--- a/src/components/Blockly/generator/math.js
+++ b/src/components/Blockly/generator/math.js
@@ -75,7 +75,7 @@ Blockly.Generator.Arduino.forBlock["math_arithmetic"] = function (block) {
   var code;
   // Power in C++ requires a special case since it has no operator.
   if (operator === " ^ ") {
-    code = `Math.pow(${argument0}, ${argument1})`;
+    code = `pow(${argument0}, ${argument1})`;
     return [code, Blockly.Generator.Arduino.ORDER_UNARY_POSTFIX];
   }
   code = argument0 + operator + argument1;

--- a/src/components/CodeEditor/LibrariesAccordion.jsx
+++ b/src/components/CodeEditor/LibrariesAccordion.jsx
@@ -13,7 +13,11 @@ import {
 } from "@mui/material";
 import * as Blockly from "blockly";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronCircleDown, faChevronDown, faExternalLink } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronCircleDown,
+  faChevronDown,
+  faExternalLink,
+} from "@fortawesome/free-solid-svg-icons";
 
 const LibrariesAccordion = ({ libraries }) => {
   return (
@@ -23,9 +27,7 @@ const LibrariesAccordion = ({ libraries }) => {
         aria-controls="libraries-content"
         id="libraries-header"
       >
-        <Typography variant="h6">
-          {Blockly.Msg.codeeditor_libraries_head}
-        </Typography>
+        <Typography>{Blockly.Msg.codeeditor_libraries_head}</Typography>
       </AccordionSummary>
       <AccordionDetails>
         <Box
@@ -75,7 +77,8 @@ const LibrariesAccordion = ({ libraries }) => {
                           Author: {library.author}
                         </Typography>
                         <Typography variant="body2" color="textSecondary">
-                          {Blockly.Msg.sensorinfo_description}: {library.sentence}
+                          {Blockly.Msg.sensorinfo_description}:{" "}
+                          {library.sentence}
                         </Typography>
                       </>
                     }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -614,13 +614,7 @@ class Navbar extends Component {
                         <FontAwesomeIcon icon={item.icon} />
                       </ListItemIcon>
                       {item.text === "Code Editor" ? (
-                        <Badge
-                          badgeContent={"Experimental"}
-                          color="primary"
-                          overlap="rectangular"
-                        >
-                          <ListItemText primary={item.text} />
-                        </Badge>
+                        <ListItemText primary={item.text} />
                       ) : (
                         <ListItemText primary={item.text} />
                       )}


### PR DESCRIPTION
This pull request includes changes to improve code readability and consistency across several files. The most important changes include modifying the `pow` function in the Arduino generator, reformatting imports, updating typography usage, and removing an experimental badge from the navbar.

Improvements to code readability and consistency:

* [`src/components/Blockly/generator/math.js`](diffhunk://#diff-71d609a115c04c951865adf1f674d5cd87efb718c5fb303d643752e52edf147eL78-R78): Changed the `pow` function call from `Math.pow` to `pow` for consistency with C++ syntax.
* [`src/components/CodeEditor/LibrariesAccordion.jsx`](diffhunk://#diff-8227313f75455eb6fabac55428cd8368f30af2ee9c7b5568196cd8cd365388eaL16-R20): Reformatted the import statements for better readability.
* [`src/components/CodeEditor/LibrariesAccordion.jsx`](diffhunk://#diff-8227313f75455eb6fabac55428cd8368f30af2ee9c7b5568196cd8cd365388eaL26-R30): Simplified the `Typography` component usage by removing the `variant` attribute where it was not necessary. [[1]](diffhunk://#diff-8227313f75455eb6fabac55428cd8368f30af2ee9c7b5568196cd8cd365388eaL26-R30) [[2]](diffhunk://#diff-8227313f75455eb6fabac55428cd8368f30af2ee9c7b5568196cd8cd365388eaL78-R81)
* [`src/components/Navbar.jsx`](diffhunk://#diff-0b9e115b879d5389a7caf5029cd442d7358dbdeffd27469a478ad90752ed3d54L617-L623): Removed the "Experimental" badge from the "Code Editor" menu item for a cleaner UI.