### PR TITLE
remove addition of underscores to variables

### DIFF
--- a/src/components/Blockly/generator/variables.js
+++ b/src/components/Blockly/generator/variables.js
@@ -56,8 +56,7 @@ const getVariableFunction = function (block) {
   //   block.getFieldValue("VAR"),
   //   Blockly.Variables.NAME_TYPE
   // );
-  var code = myVar.name.replace(/_/g, "__").replace(/[^a-zA-Z0-9_]/g, "_");
-  return [code, Blockly.Generator.Arduino.ORDER_ATOMIC];
+  return [myVar.name, Blockly.Generator.Arduino.ORDER_ATOMIC];
 };
 
 Blockly.Generator.Arduino.forBlock["variables_set_dynamic"] = setVariableFunction();


### PR DESCRIPTION
When getting a variable an extra underscore is added to underscores, but not when setting it. Declaring and using a variable which is for example called "player_1" doesnt work at the moment.

The underscores used to be added to deal with special characters, but that is handled differently now.
