### PR TITLE
predefine osem interval in toolbox

### DIFF
--- a/src/components/Blockly/toolbox/ToolboxEsp.jsx
+++ b/src/components/Blockly/toolbox/ToolboxEsp.jsx
@@ -319,6 +319,8 @@ export const ToolboxEsp = () => {
       </Category>
       <Category name="openSenseMap" colour={getColour().sensebox}>
         <Block type="sensebox_interval_timer">
+          <Field name="name">osem_interval</Field>
+          <Field name="interval">60000</Field>
           <Value name="DO">
             <Block type="sensebox_esp32s2_osem_connection" />
           </Value>

--- a/src/components/Blockly/toolbox/ToolboxMcu.jsx
+++ b/src/components/Blockly/toolbox/ToolboxMcu.jsx
@@ -325,6 +325,8 @@ export const ToolboxMcu = () => {
       </Category>
       <Category name="openSenseMap" colour={getColour().sensebox}>
         <Block type="sensebox_interval_timer">
+          <Field name="name">osem_interval</Field>
+          <Field name="interval">60000</Field>
           <Value name="DO">
             <Block type="sensebox_osem_connection" />
           </Value>


### PR DESCRIPTION
This pull request updates the default configuration for the `sensebox_interval_timer` block in both the ESP and MCU Blockly toolboxes. Specifically, it sets default values for the timer's name and interval fields to improve the user experience when adding this block.

**Blockly toolbox improvements:**

* Set the default `name` field to `osem_interval` and the `interval` field to `60000` for the `sensebox_interval_timer` block in the ESP toolbox (`ToolboxEsp.jsx`).
* Set the default `name` field to `osem_interval` and the `interval` field to `60000` for the `sensebox_interval_timer` block in the MCU toolbox (`ToolboxMcu.jsx`).