### PR TITLE
Fix: blockly toolbox styling

### DIFF
--- a/src/components/Blockly/toolbox/toolbox_styles.css
+++ b/src/components/Blockly/toolbox/toolbox_styles.css
@@ -34,7 +34,4 @@
   margin-left: 60px;
 }
 
-/* Toolbox Breite */
-.blocklyToolbox {
-  width: 15vw;
-}
+


### PR DESCRIPTION
On some screens blockly toolbox width is narrower than toolbox category width.

## Solution

Removed fixed toolbox width of 15vw.