### PR TITLE
[WIP] Feat: Embedded: autosave project + projectId routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,10 @@ class App extends Component {
                     path="/embedded/share/:shareId"
                     element={<EmbeddedBlockly />}
                   />
+                  <Route
+                    path="/embedded/project/:projectId"
+                    element={<EmbeddedBlockly />}
+                  />
                   <Route path="/embedded" element={<EmbeddedBlockly />} />
                   <Route path="/embeddedbasic" element={<BasicPage />} />
                   <Route

--- a/src/actions/projectActions.js
+++ b/src/actions/projectActions.js
@@ -173,6 +173,30 @@ export const updateProject = (type, id) => (dispatch, getState) => {
     });
 };
 
+// Silent create-or-update for autosave flows (no success snackbars/messages)
+// - If id is provided: PUT /project/:id
+// - Else: POST /project
+// Dispatches GET_PROJECT so state.project.projects[0] stays in sync.
+export const autosaveProject =
+  ({ id, xml, title }) =>
+  async (dispatch) => {
+    const body = { xml, title };
+    try {
+      const res = id
+        ? await axios.put(`${import.meta.env.VITE_BLOCKLY_API}/project/${id}`, body)
+        : await axios.post(`${import.meta.env.VITE_BLOCKLY_API}/project`, body);
+
+      const project = res?.data?.project;
+      if (project) {
+        dispatch({ type: GET_PROJECT, payload: project });
+      }
+      return project;
+    } catch (err) {
+      // no UI messaging for autosave; just propagate if caller wants to react
+      throw err;
+    }
+  };
+
 export const deleteProject = (type, id) => (dispatch, getState) => {
   const config = {
     success: (res) => {

--- a/src/components/EmbeddedBlockly.jsx
+++ b/src/components/EmbeddedBlockly.jsx
@@ -19,7 +19,7 @@ import "./EmbeddedBlockly.css";
 const EmbeddedBlockly = ({ project: propProject = null, projectType: propProjectType = null }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { shareId } = useParams();
+  const { shareId, projectId } = useParams();
   const reduxProject = useSelector((state) => state.project.projects[0]);
   const progress = useSelector((state) => state.project.progress);
   const message = useSelector((state) => state.message);
@@ -39,7 +39,8 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
     };
   }, [propProject, reduxProject, workspaceNameFromState]);
   
-  const projectType = propProjectType || (shareId ? "share" : null);
+  const projectType =
+    propProjectType || (shareId ? "share" : projectId ? "project" : null);
   
   const [initialXml, setInitialXml] = useState(() => {
     return project.xml || localStorage.getItem("autoSaveXML");
@@ -50,21 +51,34 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
     if (shareId) {
       dispatch(resetProject());
       dispatch(getProject("share", shareId));
+    } else if (projectId) {
+      dispatch(resetProject());
+      dispatch(getProject("project", projectId));
     }
     return () => {
-      if (shareId) {
+      if (shareId || projectId) {
         dispatch(resetProject());
       }
     };
-  }, [dispatch, shareId]);
+  }, [dispatch, shareId, projectId]);
 
   // Handle share loading errors
   useEffect(() => {
-    if (shareId && (message.id === "PROJECT_EMPTY" || message.id === "GET_PROJECT_FAIL")) {
+    const routeType = shareId ? "share" : projectId ? "project" : null;
+    if (
+      routeType &&
+      (message.id === "PROJECT_EMPTY" || message.id === "GET_PROJECT_FAIL")
+    ) {
       navigate("/embedded", { replace: true });
-      dispatch(returnErrors("", 404, "GET_SHARE_FAIL"));
+      dispatch(
+        returnErrors(
+          "",
+          404,
+          routeType === "share" ? "GET_SHARE_FAIL" : "GET_PROJECT_FAIL",
+        ),
+      );
     }
-  }, [shareId, message, navigate, dispatch]);
+  }, [shareId, projectId, message, navigate, dispatch]);
 
   useEffect(() => {
     if (projectType === "share") {
@@ -94,8 +108,9 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
     }
   });
 
-  // Show loading spinner if loading shared project
-  if (shareId && progress) {
+  const isLoadingProjectRoute = (shareId || projectId) && progress;
+  // Show loading spinner if loading shared/project route
+  if (isLoadingProjectRoute) {
     return (
       <Backdrop open invisible>
         <CircularProgress color="primary" />
@@ -103,8 +118,8 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
     );
   }
 
-  // Don't render if we're waiting for shared project to load
-  if (shareId && !reduxProject && !propProject) {
+  // Don't render if we're waiting for project to load
+  if ((shareId || projectId) && !reduxProject && !propProject) {
     return null;
   }
 

--- a/src/components/EmbeddedBlockly.jsx
+++ b/src/components/EmbeddedBlockly.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams, useNavigate } from "react-router-dom";
 import * as Blockly from "blockly/core";
@@ -6,7 +6,7 @@ import { createNameId } from "mnemonic-id";
 import { useEmbeddedMode } from "@/hooks/useEmbeddedMode";
 
 import { clearStats, workspaceName } from "@/actions/workspaceActions";
-import { getProject, resetProject } from "@/actions/projectActions";
+import { autosaveProject, getProject, resetProject } from "@/actions/projectActions";
 import { returnErrors } from "@/actions/messageActions";
 import BlocklyWindow from "./Blockly/BlocklyWindow";
 import DeviceSelection from "./DeviceSelection";
@@ -24,9 +24,12 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
   const progress = useSelector((state) => state.project.progress);
   const message = useSelector((state) => state.message);
   const workspaceNameFromState = useSelector((state) => state.workspace.name);
+  const workspaceXml = useSelector((state) => state.workspace.code.xml);
+
+  const [createdProject, setCreatedProject] = useState(null);
   
   const project = useMemo(() => {
-    const actualProject = propProject || reduxProject;
+    const actualProject = propProject || createdProject || reduxProject;
     if (actualProject) {
       return actualProject;
     }
@@ -37,7 +40,7 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
       shared: undefined,
       xml: localStorage.getItem("autoSaveXML") || undefined,
     };
-  }, [propProject, reduxProject, workspaceNameFromState]);
+  }, [propProject, createdProject, reduxProject, workspaceNameFromState]);
   
   const projectType =
     propProjectType || (shareId ? "share" : projectId ? "project" : null);
@@ -47,20 +50,107 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
   });
   useEmbeddedMode();
 
+  const autosaveStateRef = useRef({
+    shareId: null,
+    projectId: null,
+    title: "",
+    xml: "",
+  });
+
+  useEffect(() => {
+    autosaveStateRef.current = {
+      shareId: shareId || null,
+      projectId: projectId || null,
+      title: workspaceNameFromState || project.title || "",
+      xml: workspaceXml || project.xml || "",
+    };
+  }, [shareId, projectId, workspaceNameFromState, workspaceXml, project]);
+
+  const createInFlightRef = useRef(false);
+  const createEmbeddedProjectNow = async () => {
+    if (createInFlightRef.current) return;
+    createInFlightRef.current = true;
+    try {
+      const { title, xml } = autosaveStateRef.current;
+      const xmlToSave =
+        xml ||
+        '<xml xmlns="https://developers.google.com/blockly/xml"></xml>';
+      const created = await dispatch(
+        autosaveProject({
+          id: undefined,
+          xml: xmlToSave,
+          title: title || createNameId(),
+        }),
+      );
+      const createdId = created?._id;
+      if (created && createdId) {
+        setCreatedProject(created);
+        navigate(`/embedded/project/${createdId}`, { replace: true });
+      }
+    } catch (e) {
+    } finally {
+      createInFlightRef.current = false;
+    }
+  };
+
+  // Create the backend project immediately on /embedded (once)
+  useEffect(() => {
+    if (shareId) return; // never create when viewing a shared project
+    if (projectId) return; // already has an id
+    void createEmbeddedProjectNow();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shareId, projectId]);
+
+  useEffect(() => {
+    const intervalMs = 60_000;
+
+    const tick = async () => {
+      const { shareId: currentShareId, projectId: currentProjectId, title, xml } =
+        autosaveStateRef.current;
+
+      if (currentShareId) return;
+
+      if (!xml) return;
+
+      if (currentProjectId) {
+        try {
+          await dispatch(
+            autosaveProject({
+              id: currentProjectId,
+              xml,
+              title,
+            }),
+          );
+        } catch (e) {
+        }
+        return;
+      }
+      // No project id yet → we create immediately on board selection, so do nothing here.
+    };
+
+    const intervalId = window.setInterval(tick, intervalMs);
+    return () => window.clearInterval(intervalId);
+  }, [navigate]);
+
   useEffect(() => {
     if (shareId) {
       dispatch(resetProject());
       dispatch(getProject("share", shareId));
     } else if (projectId) {
-      dispatch(resetProject());
-      dispatch(getProject("project", projectId));
+      const alreadyHave =
+        (createdProject && createdProject._id === projectId) ||
+        (reduxProject && reduxProject._id === projectId);
+      if (!alreadyHave) {
+        dispatch(resetProject());
+        dispatch(getProject("project", projectId));
+      }
     }
     return () => {
       if (shareId || projectId) {
         dispatch(resetProject());
       }
     };
-  }, [dispatch, shareId, projectId]);
+  }, [dispatch, shareId, projectId, createdProject, reduxProject]);
 
   // Handle share loading errors
   useEffect(() => {
@@ -119,7 +209,7 @@ const EmbeddedBlockly = ({ project: propProject = null, projectType: propProject
   }
 
   // Don't render if we're waiting for project to load
-  if ((shareId || projectId) && !reduxProject && !propProject) {
+  if ((shareId || projectId) && !reduxProject && !propProject && !createdProject) {
     return null;
   }
 


### PR DESCRIPTION
- Adds a new embedded route to load existing projects: /embedded/project/:projectId.
- Updates EmbeddedBlockly to support both /embedded/share/:shareId and /embedded/project/:projectId fetching/loading in the embedded layout.
    - Implements embedded backend autosave:
    - On initial /embedded load, creates an (empty) backend project to obtain a projectId, then redirects (replace) to /embedded/project/:projectId.
    - Autosaves updates to the backend every 60s via PUT /project/:projectId.
- Does not autosave for shared routes (/embedded/share/:shareId).
- Introduces a reusable, silent autosaveProject action (create-or-update) that keeps state.project.projects[0] in sync without user-facing messages.
