### PR TITLE
Feat: add reload and autosave buttons

### DIFF
--- a/src/components/Blockly/BlocklyWindow.jsx
+++ b/src/components/Blockly/BlocklyWindow.jsx
@@ -97,10 +97,11 @@ export default function BlocklyWindow(props) {
     return () => {
       if (ws && onAnyChange) ws.removeChangeListener(onAnyChange);
       if (ws && orphanDisabler) ws.removeChangeListener(orphanDisabler);
+      if (ws && onWorkspaceChangedListener) ws.removeChangeListener(onWorkspaceChangedListener);
       // zoomToFit/backpack are tied to workspace; disposed with ws
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isEmbedded]);
 
   // Handle board change → reload XML (from localStorage or fallback)
   useEffect(() => {

--- a/src/components/Workspace/EmbeddedToolbar.jsx
+++ b/src/components/Workspace/EmbeddedToolbar.jsx
@@ -5,6 +5,8 @@ import WorkspaceName from "./ToolbarItems/WorkspaceName";
 import Compile from "./ToolbarItems/Compile";
 import ShareProject from "./ToolbarItems/ShareProject";
 import ResetWorkspace from "./ToolbarItems/ResetWorkspace";
+import ReloadWorkspace from "./ToolbarItems/ReloadWorkspace";
+import AutoSave from "./ToolbarItems/AutoSave";
 
 const EmbeddedToolbar = ({
   assessment = false,
@@ -13,6 +15,7 @@ const EmbeddedToolbar = ({
   projectType,
 }) => {
   const selectedBoard = useSelector((state) => state.board.board);
+  
   // Embedded-optimized toolbar layout for embedded mode
   return (
     <div
@@ -24,11 +27,14 @@ const EmbeddedToolbar = ({
         flexWrap: "wrap",
       }}
     >
-      <WorkspaceName
-        multiple={multiple}
-        project={project}
-        projectType={projectType}
-      />
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        {!assessment && !multiple && <AutoSave />}
+        <WorkspaceName
+          multiple={multiple}
+          project={project}
+          projectType={projectType}
+        />
+      </div>
 
       <div
         style={{
@@ -49,8 +55,8 @@ const EmbeddedToolbar = ({
             projectType={projectType}
           />
         )}
-
         {!multiple && <ResetWorkspace />}
+        {!multiple && <ReloadWorkspace />}
       </div>
     </div>
   );

--- a/src/components/Workspace/ToolbarItems/ReloadWorkspace.jsx
+++ b/src/components/Workspace/ToolbarItems/ReloadWorkspace.jsx
@@ -1,0 +1,135 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import {
+  clearStats,
+  onChangeCode,
+} from "../../../actions/workspaceActions.js";
+
+import * as Blockly from "blockly/core";
+
+import Snackbar from "../../Snackbar.jsx";
+
+import withStyles from "@mui/styles/withStyles";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import Button from "@mui/material/Button";
+
+import { faRotateRight } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const styles = (theme) => {
+  return {
+    button: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+      width: "40px",
+      height: "40px",
+      "&:hover": {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
+      },
+    },
+  };
+};
+
+class ReloadWorkspace extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      snackbar: false,
+      type: "",
+      key: "",
+      message: "",
+    };
+  }
+
+  reloadWorkspace = () => {
+    const workspace = Blockly.getMainWorkspace();
+    const savedXml = localStorage.getItem("autoSaveXML");
+    
+    if (!savedXml) {
+      this.setState({
+        snackbar: true,
+        type: "warning",
+        key: Date.now(),
+        message: Blockly.Msg.messages_reload_workspace_no_data || "Keine gespeicherten Daten gefunden.",
+      });
+      return;
+    }
+
+    try {
+      Blockly.Events.disable();
+      const xmlDom = Blockly.utils.xml.textToDom(savedXml);
+      Blockly.Xml.clearWorkspaceAndLoadFromXml(xmlDom, workspace);
+      Blockly.Events.enable();
+      
+      this.props.onChangeCode();
+      
+      this.setState({
+        snackbar: true,
+        type: "success",
+        key: Date.now(),
+        message: Blockly.Msg.messages_reload_workspace_success || "Workspace erfolgreich neu geladen.",
+      });
+    } catch (error) {
+      console.error("Failed to reload workspace:", error);
+      this.setState({
+        snackbar: true,
+        type: "error",
+        key: Date.now(),
+        message: Blockly.Msg.messages_reload_workspace_error || "Fehler beim Neu-Laden des Workspace.",
+      });
+    }
+  };
+
+  render() {
+    const tooltipText = Blockly.Msg.tooltip_reload_workspace || "Workspace neu laden";
+    return (
+      <div style={this.props.style}>
+        {this.props.isEmbedded ? (
+          <Button
+            className={`embedded-button embedded-button-secondary`}
+            onClick={this.reloadWorkspace}
+            variant="outlined"
+            startIcon={<FontAwesomeIcon icon={faRotateRight} size="sm" />}
+          >
+            Neu laden
+          </Button>
+        ) : (
+          <Tooltip title={tooltipText} arrow>
+            <IconButton
+              className={this.props.classes.button}
+              onClick={this.reloadWorkspace}
+              size="large"
+            >
+              <FontAwesomeIcon icon={faRotateRight} size="xs" />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        <Snackbar
+          open={this.state.snackbar}
+          message={this.state.message}
+          type={this.state.type}
+          key={this.state.key}
+        />
+      </div>
+    );
+  }
+}
+
+ReloadWorkspace.propTypes = {
+  onChangeCode: PropTypes.func.isRequired,
+  isEmbedded: PropTypes.bool,
+  style: PropTypes.object,
+  classes: PropTypes.object,
+};
+
+const mapStateToProps = (state) => ({
+  isEmbedded: state.general.embeddedMode,
+});
+
+export default connect(mapStateToProps, { onChangeCode })(
+  withStyles(styles, { withTheme: true })(ReloadWorkspace),
+);


### PR DESCRIPTION
## 🔄 Add AutoSave and Reload Functionality to Embedded View

### 📋 Summary

This PR adds automatic workspace saving and a reload button to the embedded Blockly view, addressing issues where users lose their work when the embedded webview hangs or needs to be refreshed (particularly in Flutter webviews).

### 🔧 Changes Made

#### New Components
- **`ReloadWorkspace.jsx`** - New toolbar button component that:
  - Loads workspace from localStorage (`autoSaveXML` key)
  - Shows success/warning/error feedback via Snackbar
  - Handles errors gracefully
  - Supports both embedded and standard modes

#### Modified Components
- **`EmbeddedToolbar.jsx`** - Integrated AutoSave icon + ReloadWorkspace button
  - AutoSave icon displays next to workspace name (left side)
  - Reload button positioned before Reset button (right side)
  - Only shown when not in assessment/multiple mode

- **`BlocklyWindow.jsx`** - **Critical bug fix**:
  - Changed useEffect dependency from `[]` to `[isEmbedded]`
  - **Why this matters**: The workspace is recreated when `isEmbedded` changes from `false` → `true`, and event listeners need to be re-attached to the new workspace instance
  - Without this fix, workspace changes weren't triggering Redux updates in embedded mode, breaking AutoSave

### 🐛 Technical Details

**Root Cause Analysis:**
The workspace initialization had a race condition:
1. Component mounts → `isEmbedded: false` (initial Redux state)
2. BlocklyComponent creates workspace with desktop config
3. BlocklyWindow attaches event listeners ✅
4. RouteHandler detects route → updates Redux: `isEmbedded: true`
5. BlocklyComponent's useEffect re-runs → **disposes old workspace, creates new one**
6. BlocklyWindow's useEffect didn't re-run (empty deps) → **new workspace has no listeners** ❌

**The Fix:**
```javascript
// Before
}, []);

// After  
}, [isEmbedded]);